### PR TITLE
Fix roon API test app for latest browser WebSocket and Roon API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 bundle.js
+.cache/
+package-lock.json
+dist/

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@
 var RoonApi          = require("node-roon-api"),
     RoonApiTransport = require('node-roon-api-transport'),
     RoonApiImage     = require('node-roon-api-image'),
+    RoonApiStatus    = require("node-roon-api-status"),
     RoonApiBrowse    = require('node-roon-api-browse'),
     Vue              = require('vue');
 
@@ -35,9 +36,10 @@ var roon = new RoonApi({
         refresh_browse();
     },
     core_unpaired: function(core_) {
-	core = undefined;
+	    core = undefined;
         v.status = 'disconnected';
-    }
+    },
+
 });
 
 roon.init_services({
@@ -51,9 +53,9 @@ var v = new Vue({
     template:            require('./root.html'),
     data:                function() {
         return {
-            server_ip:       '127.0.0.1',
-            server_port:     9100,
-            status:          'foo',
+            server_ip:       '192.168.1.10',
+            server_port:     9330,
+            status:          'ready',
             zones:           [],
             current_zone_id: null,
             listoffset:      0,
@@ -183,8 +185,30 @@ function load_browse(listoffset) {
     });
 }
 
+WebSocket.prototype.on = function(event, handler) {
+    this.addEventListener(event, handler);
+};
+WebSocket.prototype.ping = function() {
+    this.send("__ping__");
+};
+WebSocket.prototype.terminate = function() { 
+    this.close();
+};
+
 var go = function() {
     v.status = 'connecting';
-    roon.ws_connect({ host: v.server_ip, port: v.server_port, onclose: () => setTimeout(go, 3000) });
+    console.log("Connecting to Roon...");
+    roon.ws_connect({ host: v.server_ip, port: v.server_port, onclose: () => {
+        console.log(v.status);
+        /*
+        if (v.status != 'connected') {
+            setTimeout(go, 500);
+            console.log("Detected connection closing, trying to reconnect...");
+        }
+        */
+    }});
 };
+
 go();
+
+var interval = setInterval(go, 8000);

--- a/app.js
+++ b/app.js
@@ -195,20 +195,14 @@ WebSocket.prototype.terminate = function() {
     this.close();
 };
 
-var go = function() {
-    v.status = 'connecting';
+var go = function(status) {
+    v.status = status || 'connecting';
     console.log("Connecting to Roon...");
     roon.ws_connect({ host: v.server_ip, port: v.server_port, onclose: () => {
         console.log(v.status);
-        /*
-        if (v.status != 'connected') {
-            setTimeout(go, 500);
-            console.log("Detected connection closing, trying to reconnect...");
-        }
-        */
     }});
 };
 
 go();
 
-var interval = setInterval(go, 8000);
+var interval = setInterval(() => go("reconnecting"), 8000);


### PR DESCRIPTION
* Add polyfills for the native WebSocket browser implementation to be compatible with nodejs ws methods that the Roon API library uses
* Add periodic reconnect (every 8 seconds) to get around disconnect every 10 seconds due to inability of browser WebSocket to send a Ping often enough. Unfortunately there is not a solution to this without changing the Roon API behavior.

Works fine with these changes and is actually a great app for Roon; ~~however the view flashes every 8 seconds~~ and works perfectly smoothly to boot.

See issue https://github.com/RoonLabs/node-roon-api/issues/34 for core issue with roon js API using non-native WebSocket methods. Though, it is billed as a "node roon API" so not sure if that's in scope.